### PR TITLE
fix: add missing win32api import for Windows MPV monitor

### DIFF
--- a/trakt_scrobbler/player_monitors/mpv.py
+++ b/trakt_scrobbler/player_monitors/mpv.py
@@ -16,6 +16,7 @@ if os.name == 'posix':
     import select
     import socket
 elif os.name == 'nt':
+    import win32api
     import win32event
     import win32file
     import win32pipe


### PR DESCRIPTION
This fixes a bug where the Windows MPV monitor crashes with a NameError when trying to format error messages.

The problem is that the code uses win32api.FormatMessage() to format error messages when the MPV connection fails, but win32api was never imported. This causes the monitor to crash instead of handling the error gracefully.

The fix is simple - just add the missing "import win32api" to the Windows imports section.

This should resolve Windows compatibility issues that people have been reporting with MPV scrobbling.